### PR TITLE
Moved token from query param to Authorization header

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -46,8 +46,10 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(self::SYNC_URL, [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+            ],
             RequestOptions::QUERY => [
-                'token'          => $token,
                 'sync_token'     => '*',
                 'resource_types' => json_encode(['user']),
             ],


### PR DESCRIPTION
Todoist has deprecated passing a token in the query param and requires an Authorization header instead. This deprecation was final today and after the OAuth flow when Socialite attempts to get the user, a `410` is returned. 